### PR TITLE
Add sensible defaults for options.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -14,8 +14,9 @@ var LicenseGenerator = module.exports = function LicenseGenerator(args, options,
     // fs.exists is being deprecated
     this.gitc = ini.parse(this.readFileAsString(path.join(this.getUserHome(), '.gitconfig')));
   } catch (e) {
-    this.gitc = {user: {}};
+    this.gitc = {};
   }
+  this.gitc.user = this.gitc.user || {};
 };
 
 util.inherits(LicenseGenerator, yeoman.generators.Base);

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,5 @@
 'use strict';
+var ini = require('ini');
 var util = require('util');
 var path = require('path');
 var yeoman = require('yeoman-generator');
@@ -8,6 +9,13 @@ var LicenseGenerator = module.exports = function LicenseGenerator(args, options,
   yeoman.generators.Base.apply(this, arguments);
 
   this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));
+
+  try {
+    // fs.exists is being deprecated
+    this.gitc = ini.parse(this.readFileAsString(path.join(this.getUserHome(), '.gitconfig')));
+  } catch (e) {
+    this.gitc = {user: {}};
+  }
 };
 
 util.inherits(LicenseGenerator, yeoman.generators.Base);
@@ -28,7 +36,17 @@ LicenseGenerator.prototype.askFor = function askFor() {
   var prompts = [
       {
         name: 'name',
-        message: 'Please, enter your name:'
+        message: 'Please, enter your name:',
+        default: this.gitc.user.name
+      },
+      {
+        name: 'email',
+        message: 'Please, enter your email:',
+        default: this.gitc.user.email
+      },
+      {
+        name: 'website',
+        message: 'Please, enter your website address (optional):'
       },
       {
         type: 'list',
@@ -43,9 +61,20 @@ LicenseGenerator.prototype.askFor = function askFor() {
 
     // data for template
     this.year = (new Date()).getFullYear();
-    this.name = props.name;
+    this.author = props.name;
+    if (props.email) {
+      this.author += ' <' + props.email + '>';
+    }
+    if (props.website) {
+      this.author += ' (' + props.website + ')';
+    }
+    this.author = this.author.trim();
 
     this.template(filename, 'LICENSE');
     cb();
   }.bind(this));
+};
+
+LicenseGenerator.prototype.getUserHome = function getUserHome() {
+  return process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
 };

--- a/app/templates/apache.txt
+++ b/app/templates/apache.txt
@@ -1,4 +1,4 @@
-Copyright <%= year %> <%= name %>
+Copyright <%= year %> <%= author %>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/app/templates/freebsd.txt
+++ b/app/templates/freebsd.txt
@@ -1,4 +1,4 @@
-Copyright (c) <%= year %>, <%= name %>
+Copyright (c) <%= year %>, <%= author %>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/app/templates/isc.txt
+++ b/app/templates/isc.txt
@@ -1,4 +1,4 @@
-Copyright (c) <%= year %> <%= name %>
+Copyright (c) <%= year %> <%= author %>
 
 Permission to use, copy, modify, and/or distribute this software for
 any purpose with or without fee is hereby granted, provided that the

--- a/app/templates/mit.txt
+++ b/app/templates/mit.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) <%= year %> <%= name %>
+Copyright (c) <%= year %> <%= author %>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/templates/newbsd.txt
+++ b/app/templates/newbsd.txt
@@ -1,4 +1,4 @@
-Copyright (c) <%= year %>, <%= name %>
+Copyright (c) <%= year %>, <%= author %>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/app/templates/nolicense.txt
+++ b/app/templates/nolicense.txt
@@ -1,1 +1,1 @@
-Copyright (c) <%= year %> <%= name %>
+Copyright (c) <%= year %> <%= author %>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "ini": "^1.3.3",
     "yeoman-generator": "~0.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Defaults are pulled from `$HOME/.gitconfig` if that file exists.

This also adds `email` and `website` parameters. The author string is formatted according to [npm's author string format](https://docs.npmjs.com/files/package.json#people-fields-author-contributors).

All tests still pass. I can add tests for the new functionality if wanted.