### PR TITLE
feat(package): No package.json unless it already exists.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -106,17 +106,28 @@ module.exports = generators.Base.extend({
     },
 
     pkg: function () {
-      var pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
-      pkg.license = this.props.license;
+      var done = this.async();
+      var fs = require('fs');
 
-      // We don't want users to publish their module to NPM if they copyrighted
-      // their content.
-      if (this.props.license === 'nolicense') {
-        delete pkg.license;
-        pkg.private = true;
-      }
+      fs.exists(this.destinationPath('package.json'), function (exists) {
+        if (!exists) {
+          return done();
+        }
 
-      this.fs.writeJSON(this.destinationPath('package.json'), pkg);
+        var pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
+        pkg.license = this.props.license;
+
+        // We don't want users to publish their module to NPM if they copyrighted
+        // their content.
+        if (this.props.license === 'nolicense') {
+          delete pkg.license;
+          pkg.private = true;
+        }
+
+        this.fs.writeJSON(this.destinationPath('package.json'), pkg);
+
+        done();
+      }.bind(this));
     }
   }
 });

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -19,8 +19,36 @@ describe('license:app', function () {
   it('creates LICENSE file', function () {
     assert.file('LICENSE');
   });
-  it('creates package.json file', function () {
-    assert.file('package.json');
+  it('does not create package.json file', function () {
+    assert.noFile('package.json');
+  });
+});
+
+describe('license:app with package.json', function () {
+  before(function (done) {
+    helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var done = this.async();
+        var fs = require('fs');
+        fs.writeFile(path.join(dir, 'package.json'), '{}', done);
+      })
+      .withPrompts({
+        name: 'Rick',
+        email: 'foo@example.com',
+        website: 'http://example.com',
+        license: 'MIT'
+      })
+      .withOptions({
+        force: true
+      })
+      .on('end', done);
+  });
+
+  it('creates LICENSE file', function () {
+    assert.file('LICENSE');
+  });
+  it('updates package.json file with license', function () {
+    assert.fileContent('package.json', '"license": "MIT"');
   });
 });
 
@@ -33,7 +61,8 @@ describe('license:app with options', function () {
       .withOptions({
         name: 'Rick',
         email: 'foo@example.com',
-        website: 'http://example.com'
+        website: 'http://example.com',
+        force: true
       })
       .on('end', done);
   });
@@ -41,18 +70,28 @@ describe('license:app with options', function () {
   it('creates LICENSE file', function () {
     assert.fileContent('LICENSE', 'ISC');
     assert.fileContent('LICENSE', 'Rick <foo@example.com> (http://example.com)');
-    assert.fileContent('package.json', '"license": "ISC"');
+  });
+  it('does not create package.json file', function () {
+    assert.noFile('package.json');
   });
 });
 
-describe('license:app with nolicense', function () {
+describe('license:app set to nolicense with package.json', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var done = this.async();
+        var fs = require('fs');
+        fs.writeFile(path.join(dir, 'package.json'), '{}', done);
+      })
       .withPrompts({
         name: 'Rick',
         email: 'foo@example.com',
         website: 'http://example.com',
         license: 'nolicense'
+      })
+      .withOptions({
+        force: true
       })
       .on('end', done);
   });

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -7,8 +7,14 @@ var helpers = require('yeoman-generator').test;
 describe('license:app - generate Apache 2.0 license', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var done = this.async();
+        var fs = require('fs');
+        fs.writeFile(path.join(dir, 'package.json'), '{}', done);
+      })
       .withOptions({
-        year: '2015'
+        year: '2015',
+        force: true
       })
       .withPrompts({
         name: 'Rick',
@@ -31,8 +37,14 @@ describe('license:app - generate Apache 2.0 license', function () {
 describe('license:app - generate BSD 2 license', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var done = this.async();
+        var fs = require('fs');
+        fs.writeFile(path.join(dir, 'package.json'), '{}', done);
+      })
       .withOptions({
-        year: '2015'
+        year: '2015',
+        force: true
       })
       .withPrompts({
         name: 'Rick',
@@ -55,8 +67,14 @@ describe('license:app - generate BSD 2 license', function () {
 describe('license:app - generate BSD 3 license', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var done = this.async();
+        var fs = require('fs');
+        fs.writeFile(path.join(dir, 'package.json'), '{}', done);
+      })
       .withOptions({
-        year: '2015'
+        year: '2015',
+        force: true
       })
       .withPrompts({
         name: 'Rick',
@@ -79,8 +97,14 @@ describe('license:app - generate BSD 3 license', function () {
 describe('license:app - generate ISC license', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var done = this.async();
+        var fs = require('fs');
+        fs.writeFile(path.join(dir, 'package.json'), '{}', done);
+      })
       .withOptions({
-        year: '2015'
+        year: '2015',
+        force: true
       })
       .withPrompts({
         name: 'Rick',
@@ -103,8 +127,14 @@ describe('license:app - generate ISC license', function () {
 describe('license:app - generate MIT license', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var done = this.async();
+        var fs = require('fs');
+        fs.writeFile(path.join(dir, 'package.json'), '{}', done);
+      })
       .withOptions({
-        year: '2015'
+        year: '2015',
+        force: true
       })
       .withPrompts({
         name: 'Rick',
@@ -127,8 +157,14 @@ describe('license:app - generate MIT license', function () {
 describe('license:app - generate copyrighted license', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var done = this.async();
+        var fs = require('fs');
+        fs.writeFile(path.join(dir, 'package.json'), '{}', done);
+      })
       .withOptions({
-        year: '2015'
+        year: '2015',
+        force: true
       })
       .withPrompts({
         name: 'Rick',
@@ -151,8 +187,14 @@ describe('license:app - generate copyrighted license', function () {
 describe('license:app - generate unlicense license', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var done = this.async();
+        var fs = require('fs');
+        fs.writeFile(path.join(dir, 'package.json'), '{}', done);
+      })
       .withOptions({
-        year: '2015'
+        year: '2015',
+        force: true
       })
       .withPrompts({
         name: 'Rick',


### PR DESCRIPTION
Do not scaffold a package.json file unless it already exists.

This will allow projects, such as Python projects, to scaffold a LICENSE
file without inheriting a package.json file, which would make no sense
for that type of project.

BREAKING CHANGE: Will no longer scaffold package.json file unless it
already exists.

Closes #15 