### PR TITLE
remove unnecessary punctuation in copyright notice

### DIFF
--- a/app/templates/AGPL-3.0.txt
+++ b/app/templates/AGPL-3.0.txt
@@ -1,4 +1,4 @@
-Copyright (c) <%- year %>, <%- author %>
+Copyright (c) <%- year %> <%- author %>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by

--- a/app/templates/BSD-2-Clause-FreeBSD.txt
+++ b/app/templates/BSD-2-Clause-FreeBSD.txt
@@ -1,4 +1,4 @@
-Copyright (c) <%- year %>, <%- author %>
+Copyright (c) <%- year %> <%- author %>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/app/templates/BSD-3-Clause.txt
+++ b/app/templates/BSD-3-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) <%- year %>, <%- author %>
+Copyright (c) <%- year %> <%- author %>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/app/templates/GPL-3.0.txt
+++ b/app/templates/GPL-3.0.txt
@@ -1,4 +1,4 @@
-Copyright (c) <%- year %>, <%- author %>
+Copyright (c) <%- year %> <%- author %>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/app/templates/MPL-2.0.txt
+++ b/app/templates/MPL-2.0.txt
@@ -1,4 +1,4 @@
-Copyright (c) <%- year %>, <%- author %>
+Copyright (c) <%- year %> <%- author %>
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -56,7 +56,7 @@ describe('license:app - generate BSD 2 license', function () {
 
   it('creates LICENSE file using BSD 2 template', function () {
     assert.fileContent('LICENSE', 'FreeBSD Project');
-    assert.fileContent('LICENSE', 'Copyright (c) 2015, Rick <foo@example.com> (http://example.com)');
+    assert.fileContent('LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
   });
   it('creates package.json file with BSD 2 license', function () {
     assert.fileContent('package.json', '"license": "BSD-2-Clause-FreeBSD"');
@@ -85,7 +85,7 @@ describe('license:app - generate BSD 3 license', function () {
 
   it('creates LICENSE file using BSD 3 template', function () {
     assert.fileContent('LICENSE', 'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"');
-    assert.fileContent('LICENSE', 'Copyright (c) 2015, Rick <foo@example.com> (http://example.com)');
+    assert.fileContent('LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
   });
   it('creates package.json file with BSD 3 license', function () {
     assert.fileContent('package.json', '"license": "BSD-3-Clause"');
@@ -143,7 +143,7 @@ describe('license:app - generate GNU AGPL 3.0 license', function () {
 
   it('creates LICENSE file using AGPL-3.0 template', function () {
     assert.fileContent('LICENSE', 'GNU AFFERO GENERAL PUBLIC LICENSE');
-    assert.fileContent('LICENSE', 'Copyright (c) 2015, Rick <foo@example.com> (http://example.com)');
+    assert.fileContent('LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
   });
   it('creates package.json file with AGPL-3.0 license', function () {
     assert.fileContent('package.json', '"license": "AGPL-3.0"');
@@ -202,7 +202,7 @@ describe('license:app - generate MPL 2.0 license', function () {
 
   it('creates LICENSE file using MPL 2.0 template', function () {
     assert.fileContent('LICENSE', 'Mozilla Public License Version 2.0');
-    assert.fileContent('LICENSE', 'Copyright (c) 2015, Rick <foo@example.com> (http://example.com)');
+    assert.fileContent('LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
   });
   it('creates package.json file with MPL 2.0 license', function () {
     assert.fileContent('package.json', '"license": "MPL-2.0"');
@@ -289,7 +289,7 @@ describe('license:app - generate GPL-3.0 license', function () {
 
   it('creates LICENSE file using GPL-3.0 template', function () {
     assert.fileContent('LICENSE', 'GNU GENERAL PUBLIC LICENSE');
-    assert.fileContent('LICENSE', 'Copyright (c) 2015, Rick <foo@example.com> (http://example.com)');
+    assert.fileContent('LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
   });
   it('creates package.json file with GPL-3.0 license', function () {
     assert.fileContent('package.json', '"license": "GPL-3.0"');


### PR DESCRIPTION
This commit removes unnecessary punctuation in copyright notices. It
changes messages from:

    Copyright (c) <%- year %>, <%- author %>

to

    Copyright (c) <%- year %> <%- author %>

In some license files there was previously a punctuation (comma between
year and author) which isn't necessary.