### PR TITLE
standardize license names in generator and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,27 +19,28 @@ yo license
 
 ### Supported licenses
 
-* [Apache 2 License][1]
-* [MIT License][2]
-* [FreeBSD License][3]
-* [NewBSD License][4]
-* [ISC License][5]
-- [Mozilla Public License 2.0][10]
-- [GNU AGPL 3.0 License][8]
-- [GNU GPL 3.0 License][9]
-* [No License][6]
-* [Unlicense][7]
+* [Apache 2 License][10]
+* [MIT License][20]
+- [Mozilla Public License 2.0][30]
+* [BSD 2-Clause (FreeBSD) License][40]
+* [BSD 3-Clause (NewBSD) License][50]
+* [Internet Systems Consortium (ISC) License][60]
+- [GNU AGPL 3.0 License][70]
+- [GNU GPL 3.0 License][80]
+* [Unlicense][90]
+* [No License][100]
 
 ## License
 [MIT License](http://en.wikipedia.org/wiki/MIT_License)
 
-[1]: http://choosealicense.com/licenses/apache/
-[2]: http://choosealicense.com/licenses/mit/
-[3]: http://choosealicense.com/licenses/bsd/
-[4]: http://choosealicense.com/licenses/bsd-3-clause/
-[5]: http://en.wikipedia.org/wiki/ISC_license
-[6]: http://choosealicense.com/licenses/no-license/
-[7]: http://unlicense.org/
-[8]: http://choosealicense.com/licenses/agpl-3.0/
-[9]: http://choosealicense.com/licenses/gpl-3.0/
-[10]: http://choosealicense.com/licenses/mpl-2.0/
+[10]: http://choosealicense.com/licenses/apache/
+[20]: http://choosealicense.com/licenses/mit/
+[30]: http://choosealicense.com/licenses/mpl-2.0/
+[40]: http://choosealicense.com/licenses/bsd/
+[50]: http://choosealicense.com/licenses/bsd-3-clause/
+[60]: http://en.wikipedia.org/wiki/ISC_license
+[70]: http://choosealicense.com/licenses/agpl-3.0/
+[80]: http://choosealicense.com/licenses/gpl-3.0/
+[90]: http://unlicense.org/
+[100]: http://choosealicense.com/licenses/no-license/
+

--- a/app/index.js
+++ b/app/index.js
@@ -6,13 +6,12 @@ const licenses = [
   { name: 'Apache 2.0', value: 'Apache-2.0' },
   { name: 'MIT', value: 'MIT' },
   { name: 'Mozilla Public License 2.0', value: 'MPL-2.0' },
-  { name: 'Unlicense', value: 'unlicense' },
-  { name: 'FreeBSD', value: 'BSD-2-Clause-FreeBSD' },
-  { name: 'NewBSD', value: 'BSD-3-Clause' },
-  { name: 'Internet Systems Consortium (ISC)', value: 'ISC' },
+  { name: 'BSD 2-Clause (FreeBSD) License', value: 'BSD-2-Clause-FreeBSD' },
+  { name: 'BSD 3-Clause (NewBSD) License', value: 'BSD-3-Clause' },
+  { name: 'Internet Systems Consortium (ISC) License', value: 'ISC' },
   { name: 'GNU AGPL 3.0', value: 'AGPL-3.0' },
   { name: 'GNU GPL 3.0', value: 'GPL-3.0' },
-  { name: 'GNU AGPL 3.0', value: 'AGPL-3.0' },
+  { name: 'Unlicense', value: 'unlicense' },
   { name: 'No License (Copyrighted)', value: 'nolicense' }
 ];
 


### PR DESCRIPTION
This PR standardizes license names in generator and README:

- Rename `FreeBSD` to `BSD 2-Clause (FreeBSD)`
- Rename `NewBSD` to `BSD 3-Clause (NewBSD)`

These license naming previous was a bit confusing to work with and when choosing aswell.