### PR TITLE
Enable passing a selected license from options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ this.composeWith(require.resolve('generator-license'), {
   website: 'https://example.com', // (optional) Owner's website
   year: '1945', // (optional) License year (defaults to current year)
   defaultLicense: 'MIT', // (optional) Select a default license
+  license: 'MIT', // (optional) Select a license, so no license prompt will happen, in case you want to handle it outside of this generator
 });
 ```
 

--- a/app/index.js
+++ b/app/index.js
@@ -50,6 +50,12 @@ module.exports = class GeneratorLicense extends Generator {
       required: false
     });
 
+    this.option('license', {
+      type: String,
+      desc: 'Select a license, so no license prompt will happen, in case you want to handle it outside of this generator',
+      required: false
+    });
+
     this.option('output', {
       type: String,
       desc: 'Set the output file for the generated license',
@@ -88,6 +94,7 @@ module.exports = class GeneratorLicense extends Generator {
         name: 'license',
         message: 'Which license do you want to use?',
         default: this.options.defaultLicense,
+        when: this.options.license == null || licenses.find(x => x.value === this.options.license) === undefined,
         choices: licenses
       }
     ];
@@ -96,7 +103,8 @@ module.exports = class GeneratorLicense extends Generator {
       this.props = Object.assign({
         name: this.options.name,
         email: this.options.email,
-        website: this.options.website
+        website: this.options.website,
+        license: this.options.license
       }, props);
     });
   }

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -381,3 +381,63 @@ describe('license:app - generate license with output option, change directory an
 });
 
 
+describe('license:app - generate GPL-3.0 license via option', function () {
+  before(function () {
+    return helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var fs = require('fs');
+        fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+      })
+      .withOptions({
+        year: '2015',
+        force: true,
+        license: 'GPL-3.0'
+      })
+      .withPrompts({
+        name: 'Rick',
+        email: 'foo@example.com',
+        website: 'http://example.com'
+      })
+      .toPromise();
+  });
+
+  it('creates LICENSE file using GPL-3.0 template', function () {
+    assert.fileContent('LICENSE', 'GNU GENERAL PUBLIC LICENSE');
+    assert.fileContent('LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
+  });
+  it('creates package.json file with GPL-3.0 license', function () {
+    assert.fileContent('package.json', '"license": "GPL-3.0"');
+  });
+});
+
+
+describe('license:app - generate GPL-3.0 license invalid option', function () {
+  before(function () {
+    return helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var fs = require('fs');
+        fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+      })
+      .withOptions({
+        year: '2015',
+        force: true,
+        license: 'NOTVALID'
+      })
+      .withPrompts({
+        name: 'Rick',
+        email: 'foo@example.com',
+        website: 'http://example.com',
+        license: 'GPL-3.0'
+      })
+      .toPromise();
+  });
+
+  it('creates LICENSE file using GPL-3.0 template', function () {
+    assert.fileContent('LICENSE', 'GNU GENERAL PUBLIC LICENSE');
+    assert.fileContent('LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
+  });
+  it('creates package.json file with GPL-3.0 license', function () {
+    assert.fileContent('package.json', '"license": "GPL-3.0"');
+  });
+});
+


### PR DESCRIPTION
This is a way to get around https://github.com/jozefizso/generator-license/issues/37

I've tested this successfully with an old version of the generator.

Ported the changes to the new version, should work fine, but not tested by me. As I would need to bump all librarys. (will do that soon)