### PR TITLE
Add subDir option

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const Generator = require('yeoman-generator');
 const gitConfig = require('git-config');
-const path = require('path');
 
 const licenses = [
   { name: 'Apache 2.0', value: 'Apache-2.0' },
@@ -51,10 +50,11 @@ module.exports = class GeneratorLicense extends Generator {
       required: false
     });
 
-    this.option('subDir', {
+    this.option('output', {
       type: String,
-      desc: 'Optional subdirectory to write license file to',
-      required: false
+      desc: 'Set the output file for the generated license',
+      required: false,
+      defaults: 'LICENSE'
     });
   }
 
@@ -104,7 +104,6 @@ module.exports = class GeneratorLicense extends Generator {
   writing() {
     // license file
     const filename = this.props.license + '.txt';
-    const licensePath = this.options.subDir ? path.join(this.options.subDir, 'LICENSE') : 'LICENSE';
     let author = this.props.name.trim();
     if (this.props.email) {
       author += ' <' + this.props.email.trim() + '>';
@@ -115,7 +114,7 @@ module.exports = class GeneratorLicense extends Generator {
 
     this.fs.copyTpl(
       this.templatePath(filename),
-      this.destinationPath(licensePath),
+      this.destinationPath(this.options.output),
       {
         year: this.options.year,
         author: author

--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const Generator = require('yeoman-generator');
 const gitConfig = require('git-config');
+const path = require('path');
 
 const licenses = [
   { name: 'Apache 2.0', value: 'Apache-2.0' },
@@ -47,6 +48,12 @@ module.exports = class GeneratorLicense extends Generator {
     this.option('defaultLicense', {
       type: String,
       desc: 'Default license',
+      required: false
+    });
+
+    this.option('subDir', {
+      type: String,
+      desc: 'Optional subdirectory to write license file to',
       required: false
     });
   }
@@ -97,6 +104,7 @@ module.exports = class GeneratorLicense extends Generator {
   writing() {
     // license file
     const filename = this.props.license + '.txt';
+    const licensePath = this.options.subDir ? path.join(this.options.subDir, 'LICENSE') : 'LICENSE';
     let author = this.props.name.trim();
     if (this.props.email) {
       author += ' <' + this.props.email.trim() + '>';
@@ -107,7 +115,7 @@ module.exports = class GeneratorLicense extends Generator {
 
     this.fs.copyTpl(
       this.templatePath(filename),
-      this.destinationPath('LICENSE'),
+      this.destinationPath(licensePath),
       {
         year: this.options.year,
         author: author

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -317,12 +317,9 @@ describe('license:app - generate license with output option, change directory', 
       .toPromise();
   });
 
-  it('creates LICENSE file using GPL-3.0 template', function () {
-    assert.fileContent('src/LICENSE', 'GNU GENERAL PUBLIC LICENSE');
-    assert.fileContent('src/LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
-  });
-  it('creates package.json file with GPL-3.0 license', function () {
-    assert.fileContent('package.json', '"license": "GPL-3.0"');
+  it('creates license at path: src/LICENSE, no file at LICENSE', function () {
+    assert.file('src/LICENSE');
+    assert.noFile('LICENSE');
   });
 });
 
@@ -347,12 +344,9 @@ describe('license:app - generate license with output option, change directory an
       .toPromise();
   });
 
-  it('creates LICENSE file using GPL-3.0 template', function () {
-    assert.fileContent('src/license.txt', 'GNU GENERAL PUBLIC LICENSE');
-    assert.fileContent('src/license.txt', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
-  });
-  it('creates package.json file with GPL-3.0 license', function () {
-    assert.fileContent('package.json', '"license": "GPL-3.0"');
+  it('creates license at path: src/license.txt, no file at LICENSE', function () {
+    assert.file('src/license.txt');
+    assert.noFile('LICENSE');
   });
 });
 

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -296,7 +296,7 @@ describe('license:app - generate GPL-3.0 license', function () {
   });
 });
 
-describe('license:app - generate license in destination option', function () {
+describe('license:app - generate license with output option, change directory', function () {
   before(function () {
     return helpers.run(path.join(__dirname, '../app'))
       .inTmpDir(function (dir) {
@@ -320,6 +320,36 @@ describe('license:app - generate license in destination option', function () {
   it('creates LICENSE file using GPL-3.0 template', function () {
     assert.fileContent('src/LICENSE', 'GNU GENERAL PUBLIC LICENSE');
     assert.fileContent('src/LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
+  });
+  it('creates package.json file with GPL-3.0 license', function () {
+    assert.fileContent('package.json', '"license": "GPL-3.0"');
+  });
+});
+
+describe('license:app - generate license with output option, change directory and filename', function () {
+  before(function () {
+    return helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var fs = require('fs');
+        fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+      })
+      .withOptions({
+        year: '2015',
+        force: true,
+        output: 'src/license.txt'
+      })
+      .withPrompts({
+        name: 'Rick',
+        email: 'foo@example.com',
+        website: 'http://example.com',
+        license: 'GPL-3.0'
+      })
+      .toPromise();
+  });
+
+  it('creates LICENSE file using GPL-3.0 template', function () {
+    assert.fileContent('src/license.txt', 'GNU GENERAL PUBLIC LICENSE');
+    assert.fileContent('src/license.txt', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
   });
   it('creates package.json file with GPL-3.0 license', function () {
     assert.fileContent('package.json', '"license": "GPL-3.0"');

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -296,4 +296,34 @@ describe('license:app - generate GPL-3.0 license', function () {
   });
 });
 
+describe('license:app - generate license in destination option', function () {
+  before(function () {
+    return helpers.run(path.join(__dirname, '../app'))
+      .inTmpDir(function (dir) {
+        var fs = require('fs');
+        fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+      })
+      .withOptions({
+        year: '2015',
+        force: true,
+        subDir: 'src'
+      })
+      .withPrompts({
+        name: 'Rick',
+        email: 'foo@example.com',
+        website: 'http://example.com',
+        license: 'GPL-3.0'
+      })
+      .toPromise();
+  });
+
+  it('creates LICENSE file using GPL-3.0 template', function () {
+    assert.fileContent('src/LICENSE', 'GNU GENERAL PUBLIC LICENSE');
+    assert.fileContent('src/LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
+  });
+  it('creates package.json file with GPL-3.0 license', function () {
+    assert.fileContent('package.json', '"license": "GPL-3.0"');
+  });
+});
+
 

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -306,7 +306,7 @@ describe('license:app - generate license in destination option', function () {
       .withOptions({
         year: '2015',
         force: true,
-        subDir: 'src'
+        output: 'src/LICENSE'
       })
       .withPrompts({
         name: 'Rick',


### PR DESCRIPTION
Hi! 

I am using your wonderful generator in a generator I am building but I would like put the generated `LICENSE` file in sub-directory in the generated project, not in the root. I couldn't find a way to do this right now so I made this pull request to add a `subDir` option that allows just that. 

Cheers! 