### PR TITLE
Coveralls gulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: node_js
 node_js:
+  - '7'
   - '6'
   - '5'
   - '4'
+after_script:
+  - gulp coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # generator-license
 [![Build Status](https://img.shields.io/travis/jozefizso/generator-license.svg)](https://travis-ci.org/jozefizso/generator-license)
 [![NPM version](https://img.shields.io/npm/v/generator-license.svg)](https://www.npmjs.org/package/generator-license)
+[![Coverage Status](https://coveralls.io/repos/github/jozefizso/generator-license/badge.svg)](https://coveralls.io/github/jozefizso/generator-license)
 [![David Dependencies](https://img.shields.io/david/jozefizso/generator-license.svg)](https://david-dm.org/jozefizso/generator-license)
 [![David Dev Dependencies](https://img.shields.io/david/dev/jozefizso/generator-license.svg)](https://david-dm.org/jozefizso/generator-license#info=devDependencies)
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
 'use strict';
 var path = require('path');
 var gulp = require('gulp');
-var eslint = require('gulp-eslint');
 var excludeGitignore = require('gulp-exclude-gitignore');
 var mocha = require('gulp-mocha');
 var istanbul = require('gulp-istanbul');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,44 @@
+'use strict';
+var path = require('path');
+var gulp = require('gulp');
+var eslint = require('gulp-eslint');
+var excludeGitignore = require('gulp-exclude-gitignore');
+var mocha = require('gulp-mocha');
+var istanbul = require('gulp-istanbul');
+var plumber = require('gulp-plumber');
+var coveralls = require('gulp-coveralls');
+
+gulp.task('pre-test', function () {
+  return gulp.src('app/**/*.js')
+    .pipe(excludeGitignore())
+    .pipe(istanbul({
+      includeUntested: true
+    }))
+    .pipe(istanbul.hookRequire());
+});
+
+gulp.task('test', ['pre-test'], function (cb) {
+  var mochaErr;
+
+  gulp.src('test/**/*.js')
+    .pipe(plumber())
+    .pipe(mocha({reporter: 'spec'}))
+    .on('error', function (err) {
+      mochaErr = err;
+    })
+    .pipe(istanbul.writeReports())
+    .on('end', function () {
+      cb(mochaErr);
+    });
+});
+
+gulp.task('coveralls', function () {
+  return gulp.src('coverage/**/lcov.info')
+    .pipe(coveralls());
+});
+
+gulp.task('watch', function () {
+  gulp.watch(['app/**/*.js', 'test/**'], ['test']);
+});
+
+gulp.task('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -23,13 +23,19 @@
     "app"
   ],
   "scripts": {
-    "test": "mocha -R spec"
+    "test": "gulp"
   },
   "dependencies": {
     "git-config": "^0.0.7",
     "yeoman-generator": "^1.0.1"
   },
   "devDependencies": {
+    "gulp": "^3.9.0",
+    "gulp-coveralls": "^0.1.4",
+    "gulp-exclude-gitignore": "^1.0.0",
+    "gulp-istanbul": "^1.0.0",
+    "gulp-mocha": "^3.0.1",
+    "gulp-plumber": "^1.0.0",
     "process": "^0.11.9",
     "mocha": "^3.2.0",
     "yeoman-assert": "^2.2.2",


### PR DESCRIPTION
Add coveralls support. For this I have moved Mocha tests to be executed via Gulp (it sets up Istambul for coverage reporting).

I have also added `gulp coveralls` `after_script` in `.travis.yml`. This will fix #55 and enable coveralls.io integration once owners of the repository set up the link on https://coveralls.io/ website.

This will also allow me to setup easy linting on top of gulp via eslintrc for the next PR to fix #54 .

