### PR TITLE
update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
 * text=auto
+
+/__tests__ export-ignore
+/.editorconfig export-ignore
+/.gitignore export-ignore
+/.jshintrc export-ignore
+/.travis.yml export-ignore
+


### PR DESCRIPTION
add non-distributable (dev) files to gitattributes so they are ignored on regular install