### PR TITLE
Trim email and website before testing.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -91,13 +91,13 @@ module.exports = class GeneratorLicense extends Generator {
         name: 'email',
         message: 'Your email (optional):',
         default: this.options.email || this.gitc.user.email,
-        when: !this.options.email
+        when: this.options.email === null || this.options.email === undefined
       },
       {
         name: 'website',
         message: 'Your website (optional):',
         default: this.options.website,
-        when: !this.options.website
+        when: this.options.website === null || this.options.website === undefined
       },
       {
         type: 'list',
@@ -128,10 +128,10 @@ module.exports = class GeneratorLicense extends Generator {
     // License file
     const filename = this.props.license + '.txt';
     let author = this.props.name.trim();
-    if (this.props.email !== undefined) {
+    if (this.props.email && this.props.email.trim()) {
       author += ' <' + this.props.email.trim() + '>';
     }
-    if (this.props.website !== undefined) {
+    if (this.props.website && this.props.website.trim()) {
       author += ' (' + this.props.website.trim() + ')';
     }
 

--- a/app/index.js
+++ b/app/index.js
@@ -128,10 +128,10 @@ module.exports = class GeneratorLicense extends Generator {
     // License file
     const filename = this.props.license + '.txt';
     let author = this.props.name.trim();
-    if (this.props.email) {
+    if (this.props.email.trim()) {
       author += ' <' + this.props.email.trim() + '>';
     }
-    if (this.props.website) {
+    if (this.props.website.trim()) {
       author += ' (' + this.props.website.trim() + ')';
     }
 

--- a/app/index.js
+++ b/app/index.js
@@ -128,10 +128,10 @@ module.exports = class GeneratorLicense extends Generator {
     // License file
     const filename = this.props.license + '.txt';
     let author = this.props.name.trim();
-    if (this.props.email.trim()) {
+    if (this.props.email !== undefined) {
       author += ' <' + this.props.email.trim() + '>';
     }
-    if (this.props.website.trim()) {
+    if (this.props.website !== undefined) {
       author += ' (' + this.props.website.trim() + ')';
     }
 

--- a/app/index.js
+++ b/app/index.js
@@ -91,13 +91,13 @@ module.exports = class GeneratorLicense extends Generator {
         name: 'email',
         message: 'Your email (optional):',
         default: this.options.email || this.gitc.user.email,
-        when: this.options.email === null || this.options.email === undefined
+        when: !this.options.email
       },
       {
         name: 'website',
         message: 'Your website (optional):',
         default: this.options.website,
-        when: this.options.website === null || this.options.website === undefined
+        when: !this.options.website
       },
       {
         type: 'list',

--- a/app/index.js
+++ b/app/index.js
@@ -91,13 +91,13 @@ module.exports = class GeneratorLicense extends Generator {
         name: 'email',
         message: 'Your email (optional):',
         default: this.options.email || this.gitc.user.email,
-        when: this.options.email === null || this.options.email === undefined
+        when: this.options.email === null || this.options.email === undefined || this.options.email === ""
       },
       {
         name: 'website',
         message: 'Your website (optional):',
         default: this.options.website,
-        when: this.options.website === null || this.options.website === undefined
+        when: this.options.website === null || this.options.website === undefined || this.options.website === ""
       },
       {
         type: 'list',

--- a/app/index.js
+++ b/app/index.js
@@ -91,13 +91,13 @@ module.exports = class GeneratorLicense extends Generator {
         name: 'email',
         message: 'Your email (optional):',
         default: this.options.email || this.gitc.user.email,
-        when: !this.options.email
+        when: this.options.email === null || this.options.email === undefined
       },
       {
         name: 'website',
         message: 'Your website (optional):',
         default: this.options.website,
-        when: !this.options.website
+        when: this.options.website === null || this.options.website === undefined
       },
       {
         type: 'list',


### PR DESCRIPTION
I query for email, name and website in my own generator, which I then pass to this generator when composingWith.

Problem is, if a user doesn't specify (in my own prompts) a name or website for example, then a falsy value is passed down to this generator, and the user is prompted again for a field he already skipped.

With my tiny patch, I can pass ```this.props.email || ' '``` to composeWith() and

1. The user won't be prompted again.
2. An empty () won't be added to the licence.

Unrelated: I haven't found a way from another generator (composingWith this one) to retrieve the email, website and name values. That would certainly be preferable.