### PR TITLE
Fix removing `license` in package.json when `UNLICENSED`

### DIFF
--- a/__tests__/test-app.js
+++ b/__tests__/test-app.js
@@ -72,6 +72,7 @@ describe('license:app', () => {
         license: 'UNLICENSED'
       })
       .then(() => {
+        assert.fileContent('package.json', '"license": "UNLICENSED"');
         assert.fileContent('package.json', '"private": true');
       });
   });

--- a/__tests__/test-app.js
+++ b/__tests__/test-app.js
@@ -72,7 +72,6 @@ describe('license:app', () => {
         license: 'UNLICENSED'
       })
       .then(() => {
-        assert.noFileContent('package.json', '"license"');
         assert.fileContent('package.json', '"private": true');
       });
   });

--- a/__tests__/test-creation.js
+++ b/__tests__/test-creation.js
@@ -241,7 +241,6 @@ describe('license:app - generate copyrighted license', () => {
 
   it('creates LICENSE file using UNLICENSED template', () => {
     assert.fileContent('LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
-    assert.noFileContent('package.json', '"license"');
     assert.fileContent('package.json', '"private": true');
   });
 });

--- a/__tests__/test-creation.js
+++ b/__tests__/test-creation.js
@@ -241,6 +241,7 @@ describe('license:app - generate copyrighted license', () => {
 
   it('creates LICENSE file using UNLICENSED template', () => {
     assert.fileContent('LICENSE', 'Copyright (c) 2015 Rick <foo@example.com> (http://example.com)');
+    assert.fileContent('package.json', '"license": "UNLICENSED"');
     assert.fileContent('package.json', '"private": true');
   });
 });

--- a/app/index.js
+++ b/app/index.js
@@ -163,7 +163,6 @@ module.exports = class GeneratorLicense extends Generator {
       (this.options.publish === undefined && this.props.license === 'UNLICENSED') ||
       this.options.publish === false
     ) {
-      delete pkg.license;
       pkg.private = true;
     }
 


### PR DESCRIPTION
According to [NPM documentation](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license), the `license` key in package.json should still be present, using `UNLICENSED` as value:

> Finally, if you do not wish to grant others the right to use a private or unpublished package under any terms:
> {
>   "license": "UNLICENSED"
> }

Fixes #89.